### PR TITLE
Scatter plot

### DIFF
--- a/kivy_garden/graph/__init__.py
+++ b/kivy_garden/graph/__init__.py
@@ -1527,6 +1527,32 @@ class VBar(MeshLinePlot):
             vert[k * 8 + 5] = px_ymax
         mesh.vertices = vert
 
+class ScatterPlot(Plot):
+    """ScatterPlot draws using a standard Point object.
+    """
+
+    pointsize = NumericProperty(1)
+
+    def create_drawings(self):
+        from kivy.graphics import Point, RenderContext
+
+        self._grc = RenderContext(
+                use_parent_modelview=True,
+                use_parent_projection=True)
+        with self._grc:
+            self._gcolor = Color(*self.color)
+            self._gpts = Point(points=[], pointsize=self.pointsize)
+
+        return [self._grc]
+
+    def draw(self, *args):
+        super(ScatterPlot, self).draw(*args)
+        # flatten the list
+        points = []
+        for x, y in self.iterate_points():
+            points += [x, y]
+        self._gpts.points = points
+
 
 if __name__ == '__main__':
     import itertools
@@ -1625,6 +1651,10 @@ if __name__ == '__main__':
 
                 Clock.schedule_interval(self.update_contour, 1 / 60.)
 
+            # Test the scatter plot
+            plot = ScatterPlot(color=next(colors), pointsize=5)
+            graph.add_plot(plot)
+            plot.points = [(x, .1 + randrange(10) / 10.) for x in range(-50, 1)]
             return b
 
         def make_contour_data(self, ts=0):

--- a/kivy_garden/graph/__init__.py
+++ b/kivy_garden/graph/__init__.py
@@ -1537,7 +1537,7 @@ class ScatterPlot(Plot):
     >>> plot = ScatterPlot(color=[1, 0, 0, 1], pointsize=5)
     """
 
-    pointsize = NumericProperty(1)
+    point_size = NumericProperty(1)
 
     def create_drawings(self):
         from kivy.graphics import Point, RenderContext
@@ -1547,7 +1547,7 @@ class ScatterPlot(Plot):
                 use_parent_projection=True)
         with self._points_context:
             self._gcolor = Color(*self.color)
-            self._gpts = Point(points=[], pointsize=self.pointsize)
+            self._gpts = Point(points=[], pointsize=self.point_size)
 
         return [self._points_context]
 

--- a/kivy_garden/graph/__init__.py
+++ b/kivy_garden/graph/__init__.py
@@ -1528,7 +1528,12 @@ class VBar(MeshLinePlot):
         mesh.vertices = vert
 
 class ScatterPlot(Plot):
-    """ScatterPlot draws using a standard Point object.
+    """
+    ScatterPlot draws using a standard Point object.
+    The pointsize can be controlled by passing `pointsize` when initialising
+    the class. Default pointsize is 1.0.
+
+    >>> plot = ScatterPlot(color=[1, 0, 0, 1], pointsize=5)
     """
 
     pointsize = NumericProperty(1)

--- a/kivy_garden/graph/__init__.py
+++ b/kivy_garden/graph/__init__.py
@@ -1556,6 +1556,10 @@ class ScatterPlot(Plot):
         # flatten the list
         self._gpts.points = list(chain(*self.iterate_points()))
 
+    def on_point_size(self, *largs):
+        if hasattr(self, "_gpts"):
+            self._gpts.pointsize = self.point_size
+
 
 if __name__ == '__main__':
     import itertools

--- a/kivy_garden/graph/__init__.py
+++ b/kivy_garden/graph/__init__.py
@@ -69,6 +69,7 @@ from kivy.logger import Logger
 from kivy import metrics
 from math import log10, floor, ceil
 from decimal import Decimal
+from itertools import chain
 try:
     import numpy as np
 except ImportError as e:
@@ -1541,22 +1542,19 @@ class ScatterPlot(Plot):
     def create_drawings(self):
         from kivy.graphics import Point, RenderContext
 
-        self._grc = RenderContext(
+        self._points_context = RenderContext(
                 use_parent_modelview=True,
                 use_parent_projection=True)
-        with self._grc:
+        with self._points_context:
             self._gcolor = Color(*self.color)
             self._gpts = Point(points=[], pointsize=self.pointsize)
 
-        return [self._grc]
+        return [self._points_context]
 
     def draw(self, *args):
         super(ScatterPlot, self).draw(*args)
         # flatten the list
-        points = []
-        for x, y in self.iterate_points():
-            points += [x, y]
-        self._gpts.points = points
+        self._gpts.points = list(chain(*self.iterate_points()))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR implements a separate `ScatterPlot` class. The class draws using the standard `Point` function. The main difference between the `ScatterPlot` class and the `MeshLinePlot` class with `mode='points'` is that the point size can easily be tuned by passing it when initialising the `ScatterPlot`