### PR TITLE
BUG: To many elements in vertices deleted

### DIFF
--- a/kivy_garden/graph/__init__.py
+++ b/kivy_garden/graph/__init__.py
@@ -1425,7 +1425,7 @@ class BarPlot(Plot):
         ind = mesh.indices
         diff = len(points) * 6 - len(vert) // 4
         if diff < 0:
-            del vert[4 * point_len:]
+            del vert[24 * point_len:]
             del ind[point_len:]
         elif diff > 0:
             ind.extend(range(len(ind), len(ind) + diff))


### PR DESCRIPTION
It looks like `BarPlot` deletes too many elements in the `vertices` array when the number of points is reduced. It looks like there should be 24 entries for each point. From quick tests the code crashes in its current form, and behaves correctly after the proposed change.