### PR TITLE
Fix example code snipped: import syntax was outdated

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ a red line plot containing a sin wave on this range::
 
 ```python
 from math import sin
-from kivy.garden.graph import Graph, MeshLinePlot
+from kivy_garden.graph import Graph, MeshLinePlot
 graph = Graph(xlabel='X', ylabel='Y', x_ticks_minor=5,
 x_ticks_major=25, y_ticks_major=1,
 y_grid_label=True, x_grid_label=True, padding=5,


### PR DESCRIPTION
It seems that the correct syntax to import flowers in kivy has changed, but the example code snippet in README.md is outdated.

This trivial one-commit PR fixes it.